### PR TITLE
docs: Remove check for head commit

### DIFF
--- a/examples/01-workflow-dispatch/release-publish.yml
+++ b/examples/01-workflow-dispatch/release-publish.yml
@@ -13,7 +13,6 @@ jobs:
       contents: write
       id-token: write # Required for authentication using OIDC
     runs-on: [ ubuntu-latest ]
-    if: contains(github.event.head_commit.message, 'chore(release)')
     steps:
       - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2

--- a/examples/02-release-on-pr/release-publish.yml
+++ b/examples/02-release-on-pr/release-publish.yml
@@ -13,7 +13,6 @@ jobs:
       contents: write
       id-token: write # Required for authentication using OIDC
     runs-on: [ ubuntu-latest ]
-    if: contains(github.event.head_commit.message, 'chore(release)')
     steps:
       - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2


### PR DESCRIPTION
The check for the head commit should not be engaged as publishing can only happen by tag, and one should be able to publish a tag, even if it does not contain the `chore(release)` message as last commit. For the `release-tag` workflow, it makes absolutely sense, though.