### PR TITLE
feat: Allow versioning non-published packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ action, they are all optional.
 | enforce-lockfile          | false                 | Whether the versions in the lockfiles should be enforced.        |
 | run-versioning            | false                 | Whether packages should be versioned.                            |
 | run-versioning-prerelease | false                 | Whether packages should be versioned as a prerelease.            |
-| version-all               | false                 | Whether to include or exclude packages with `publish_to: "none"` |
+| include-private           | false                 | Whether to include or exclude packages with `publish_to: "none"` |
 | publish-dry-run           | false                 | Whether packages should be dry-run published.                    |
 | publish                   | false                 | Whether packages should be published to pub.dev.                 |
 | create-pr                 | false                 | Whether to create a PR with the changes made by Melos.           |

--- a/README.md
+++ b/README.md
@@ -41,19 +41,20 @@ steps:
 There are a few parameters that can be set to customize the behavior of the
 action, they are all optional.
 
-| Parameter                 | Default               | Description                                               |
-|---------------------------|-----------------------|-----------------------------------------------------------|
-| melos-version             | latest                | The version of Melos to activate.                         |
-| run-bootstrap             | true                  | Whether to run `melos bootstrap` after activating Melos.  |
-| enforce-lockfile          | false                 | Whether the versions in the lockfiles should be enforced. |
-| run-versioning            | false                 | Whether packages should be versioned.                     |
-| run-versioning-prerelease | false                 | Whether packages should be versioned as a prerelease.     |
-| publish-dry-run           | false                 | Whether packages should be dry-run published.             |
-| publish                   | false                 | Whether packages should be published to pub.dev.          |
-| create-pr                 | false                 | Whether to create a PR with the changes made by Melos.    |
-| tag                       | false                 | Whether tags for the packages should be created.          |
-| git-email                 | contact@blue-fire.xyz | The email to use when committing changes.                 |
-| git-name                  | Melos Action          | The name to use when committing changes.                  |
+| Parameter                 | Default               | Description                                                      |
+|---------------------------|-----------------------|------------------------------------------------------------------|
+| melos-version             | latest                | The version of Melos to activate.                                |
+| run-bootstrap             | true                  | Whether to run `melos bootstrap` after activating Melos.         |
+| enforce-lockfile          | false                 | Whether the versions in the lockfiles should be enforced.        |
+| run-versioning            | false                 | Whether packages should be versioned.                            |
+| run-versioning-prerelease | false                 | Whether packages should be versioned as a prerelease.            |
+| version-all               | false                 | Whether to include or exclude packages with `publish_to: "none"` |
+| publish-dry-run           | false                 | Whether packages should be dry-run published.                    |
+| publish                   | false                 | Whether packages should be published to pub.dev.                 |
+| create-pr                 | false                 | Whether to create a PR with the changes made by Melos.           |
+| tag                       | false                 | Whether tags for the packages should be created.                 |
+| git-email                 | contact@blue-fire.xyz | The email to use when committing changes.                        |
+| git-name                  | Melos Action          | The name to use when committing changes.                         |
 
 To set a specific parameter you use the `with` keyword in your action, like in
 the example below.

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,10 @@ inputs:
     description: 'Whether packages should be versioned as a prerelease (default: false)'
     required: false
     default: 'false'
+  version-all:
+    description: 'Whether to include or exclude packages with `publish_to: "none"` (default: false)'
+    required: false
+    default: 'false'
   publish-dry-run:
     description: 'Whether packages should be dry-run published (default: false)'
     required: false
@@ -73,11 +77,11 @@ runs:
       shell: bash
     - name: 'Run melos version'
       if: ${{ inputs.run-versioning == 'true' }}
-      run: melos version --yes --no-git-tag-version
+      run: melos version --yes --no-git-tag-version ${{ (inputs.version-all == 'true' && '--all') || '' }}
       shell: bash
     - name: 'Run melos version as a prerelease'
       if: ${{ inputs.run-versioning-prerelease == 'true' }}
-      run: melos version --yes --no-git-tag-version --prerelease
+      run: melos version --yes --no-git-tag-version --prerelease ${{ (inputs.version-all == 'true' && '--all') || '' }}
       shell: bash
     - name: 'Run melos publish (dry run)'
       if: ${{ inputs.publish-dry-run == 'true' }}

--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ inputs:
     description: 'Whether packages should be versioned as a prerelease (default: false)'
     required: false
     default: 'false'
-  version-all:
+  include-private:
     description: 'Whether to include or exclude packages with `publish_to: "none"` (default: false)'
     required: false
     default: 'false'
@@ -77,11 +77,11 @@ runs:
       shell: bash
     - name: 'Run melos version'
       if: ${{ inputs.run-versioning == 'true' }}
-      run: melos version --yes --no-git-tag-version ${{ (inputs.version-all == 'true' && '--all') || '' }}
+      run: melos version --yes --no-git-tag-version ${{ (inputs.include-private == 'true' && '--all') || '' }}
       shell: bash
     - name: 'Run melos version as a prerelease'
       if: ${{ inputs.run-versioning-prerelease == 'true' }}
-      run: melos version --yes --no-git-tag-version --prerelease ${{ (inputs.version-all == 'true' && '--all') || '' }}
+      run: melos version --yes --no-git-tag-version --prerelease ${{ (inputs.include-private == 'true' && '--all') || '' }}
       shell: bash
     - name: 'Run melos publish (dry run)'
       if: ${{ inputs.publish-dry-run == 'true' }}
@@ -99,7 +99,7 @@ runs:
       run: |
         # We don't care about errors due to creating new tags (`|| true`)
         # since for all packages that didn't get a new release, the tag already exists.
-        melos exec -c 1 --no-private -- git tag \$MELOS_PACKAGE_NAME-v\$MELOS_PACKAGE_VERSION || true
+        melos exec -c 1 ${{ (inputs.include-private == 'true' && '--private') || '--no-private' }} -- git tag \$MELOS_PACKAGE_NAME-v\$MELOS_PACKAGE_VERSION || true
         git push --tags
       shell: bash
     - name: 'Extract tag info'

--- a/examples/01-workflow-dispatch/release-tag.yml
+++ b/examples/01-workflow-dispatch/release-tag.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           tag: true
       - run: |
-          melos exec -c1 --no-published --no-private --order-dependents -- \
+          melos exec -c 1 --no-published --no-private --order-dependents -- \
           gh workflow run release-publish.yml \
           --ref \$MELOS_PACKAGE_NAME-v\$MELOS_PACKAGE_VERSION
         env:

--- a/examples/02-release-on-pr/release-tag.yml
+++ b/examples/02-release-on-pr/release-tag.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           tag: true
       - run: |
-          melos exec -c1 --no-published --no-private --order-dependents -- \
+          melos exec -c 1 --no-published --no-private --order-dependents -- \
           gh workflow run release-publish.yml \
           --ref \$MELOS_PACKAGE_NAME-v\$MELOS_PACKAGE_VERSION
         env:


### PR DESCRIPTION
This is needed, e.g. when app developers create a common package for their needs, but isn't meant to be published to pub.dev.

Example workflow: https://github.com/Oberhauser-Dev/wrestling_scoreboard/actions/runs/11755620616/job/32750863728#step:4:258