### PR TITLE
feat: Support build metadata / pre-releases in semver spec

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -106,8 +106,9 @@ runs:
       if: ${{ inputs.publish == 'true' }}
       env:
         GITHUBREF: ${{ github.ref }}
+      # Support semver, e.g.: "refs/tags/my_package-v1.2.3+alpha.1"
       run: |
-        PACKAGE_NAME=$(sed -E 's/refs\/tags\/([a-z0-9_]+)-v([0-9]+\.[0-9]+\.[0-9]+)/\1/' <<< $GITHUBREF) && \
+        PACKAGE_NAME=$(sed -E 's/refs\/tags\/([a-z0-9_]+)-v([0-9]+\.[0-9]+\.[0-9]+.*)$/\1/' <<< $GITHUBREF) && \
         echo "PACKAGE_NAME=$PACKAGE_NAME" >> $GITHUB_ENV
         echo "Package name: $PACKAGE_NAME"
       shell: bash


### PR DESCRIPTION
I originally thought to use semver string: https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string.

But its somehow not working with sed, and also to complex as we don't need to know the partitions of the version string.

So now to test:
```shell
GITHUBREF=refs/tags/my_package-v1.2.3+alpha.1
PACKAGE_NAME=$(sed -E 's/refs\/tags\/([a-z0-9_]+)-v([0-9]+\.[0-9]+\.[0-9]+.*)$/\1/' <<< $GITHUBREF)
echo "Package name: $PACKAGE_NAME"
```