### PR TITLE
Pin GitHub Actions to specific commit SHAs for improved security

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -108,7 +108,7 @@ runs:
       shell: bash
     - name: 'Create Pull Request with changes'
       if: ${{ inputs.create-pr == 'true' }}
-      uses: peter-evans/create-pull-request@v6
+      uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
       with:
         title: 'chore(release): Publish packages'
         body: 'Prepared all packages to be released to pub.dev'
@@ -133,7 +133,7 @@ runs:
       shell: bash
     - name: 'Installs the Dart SDK and sets up the pipeline for usage with pub.dev (this sets up OIDC)'
       if: ${{ inputs.publish == 'true' }}
-      uses: dart-lang/setup-dart@v1
+      uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c # v1.7.1
       with:
         sdk: ${{ inputs.dart-version }}
     - name: 'Publish package related to tag to pub.dev'


### PR DESCRIPTION
## Changes

  - Pin peter-evans/create-pull-request from @v6 to @c5a7806660adbe173f04e3e038b0ccdcd758773c (v6.1.0)
  - Pin dart-lang/setup-dart from @v1 to @e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c (v1.7.1)

These changes were automatically generated using https://github.com/suzuki-shunsuke/pinact, a tool that pins GitHub Actions to their corresponding commit SHAs.

**No behavior changes expected** - this is purely a security enhancement that pins existing versions to their exact commit references. The functionality remains identical.

## Motivation

Using commit SHAs instead of version tags prevents supply chain attacks where malicious actors could compromise tags or releases. This follows GitHub's security best practices for Actions workflows.

> Pinning an action to a full length commit SHA is currently the only way to use an action as an immutable release. Pinning to a particular SHA helps mitigate the risk of a bad actor adding a backdoor to the action's repository, as they would need to generate a SHA-1 collision for a valid Git object payload. When selecting a SHA, you should verify it is from the action's repository and not a repository fork.
> https://docs.github.com/en/actions/reference/security/secure-use#using-third-party-actions