### PR TITLE
fix: push tags one by one

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -121,7 +121,8 @@ runs:
         # We don't care about errors due to creating new tags (`|| true`)
         # since for all packages that didn't get a new release, the tag already exists.
         melos exec -c 1 ${{ (inputs.include-private == 'true' && '--private') || '--no-private' }} -- git tag \$MELOS_PACKAGE_NAME-v\$MELOS_PACKAGE_VERSION || true
-        git push --tags
+        git push --no-follow-tags
+        for tag in $(git tag --points-at HEAD); do git push origin "$tag"; done
       shell: bash
     - name: 'Extract tag info'
       if: ${{ inputs.publish == 'true' }}

--- a/action.yml
+++ b/action.yml
@@ -121,6 +121,7 @@ runs:
         # We don't care about errors due to creating new tags (`|| true`)
         # since for all packages that didn't get a new release, the tag already exists.
         melos exec -c 1 ${{ (inputs.include-private == 'true' && '--private') || '--no-private' }} -- git tag \$MELOS_PACKAGE_NAME-v\$MELOS_PACKAGE_VERSION || true
+        # Push tags one by one to avoid github limitation on emmiting new tag event
         git push --no-follow-tags
         for tag in $(git tag --points-at HEAD); do git push origin "$tag"; done
       shell: bash


### PR DESCRIPTION
This change is fixing an edge case for monorepos, when versioning produce more than 3 tags and there're downstream actions dependent on new tag event.

We were having issues with downstream jobs, that are running on tags. GitHub support confirmed, that when more than 3 tags are included in the push, no new tag events are emitted, which breaks the pipelines if they're triggered by tag creation. 
