### PR TITLE
feat: add token input for create-pr step

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ action, they are all optional.
 | publish                   | false                 | Whether packages should be published to pub.dev.                                                             |
 | dart-version              | stable                | The Dart version that should be used for OIDC setup for publishing. Pass in `'none'` to setup this manually. |
 | create-pr                 | false                 | Whether to create a PR with the changes made by Melos.                                                       |
+| token                     | GITHUB_TOKEN          | Token used when creating the PR. Use a PAT or GitHub App token to trigger workflows on the created PR.       |
 | tag                       | false                 | Whether tags for the packages should be created.                                                             |
 | git-email                 | contact@blue-fire.xyz | The email to use when committing changes.                                                                    |
 | git-name                  | Melos Action          | The name to use when committing changes.                                                                     |
@@ -135,6 +136,23 @@ And this note is worth repeating - Remember to check the "Allow GitHub Actions
 to create and approve pull requests" checkbox in the bottom of the
 Actions > General section of your repository settings if you want to use
 `create-pr: true`.
+
+#### Using a custom token for PR creation
+
+By default, PRs created by the action use the `GITHUB_TOKEN`, which does not
+trigger downstream workflows (e.g. CI checks) on the created PR. To work around
+this, pass a PAT or GitHub App token via the `token` input:
+
+```yaml
+steps:
+  - uses: actions/checkout@v4
+  - uses: subosito/flutter-action@v2
+  - uses: bluefireteam/melos-action@v3
+    with:
+      run-versioning: true
+      create-pr: true
+      token: ${{ secrets.MY_GITHUB_PAT }}
+```
 
 See the [examples directory](./examples) to get files that you can copy and
 paste into your repository.

--- a/action.yml
+++ b/action.yml
@@ -65,6 +65,10 @@ inputs:
     description: 'Whether a PR should be created with the versioning changes (default: false)'
     required: false
     default: 'false'
+  token:
+    description: 'Token to use when creating the PR. Use a PAT or GitHub App token to trigger workflows on the created PR (default: GITHUB_TOKEN)'
+    required: false
+    default: ${{ github.token }}
   git-email:
     description: 'The email to use when committing changes'
     required: false
@@ -112,6 +116,7 @@ runs:
       if: ${{ inputs.create-pr == 'true' }}
       uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
       with:
+        token: ${{ inputs.token }}
         title: 'chore(release): Publish packages'
         body: 'Prepared all packages to be released to pub.dev'
         branch: release-${{github.run_id}}


### PR DESCRIPTION
## Summary

- Add optional `token` input to pass a custom token (PAT or GitHub App token) to the `peter-evans/create-pull-request` step
- Defaults to `github.token` so existing behavior is unchanged

## Motivation

The default `GITHUB_TOKEN` does not trigger downstream workflows on PRs it creates. Users who need CI checks to run on release PRs currently have no way to provide a custom token.

Closes #38

## Test plan

- [ ] Verify existing `create-pr: true` workflows still work without specifying `token` (defaults to `GITHUB_TOKEN`)
- [ ] Verify passing a PAT via `token` input triggers downstream workflows on the created PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)