### PR TITLE
feat: automatically create GitHub releases after publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ action, they are all optional.
 | include-private           | false                                           | Whether to include or exclude packages with `publish_to: "none"`                                             |
 | publish-dry-run           | false                                           | Whether packages should be dry-run published.                                                                |
 | publish                   | false                                           | Whether packages should be published to pub.dev.                                                             |
+| create-release            | false                                           | Whether a GitHub release (with notes from the package's CHANGELOG.md) should be created for the tagged package. |
+| release-prerelease        | auto                                            | Whether the GitHub release is marked as a prerelease. `auto` detects it from the version (any `-` suffix).    |
 | dart-version              | stable                                          | The Dart version that should be used for OIDC setup for publishing. Pass in `'none'` to setup this manually. |
 | create-pr                 | false                                           | Whether to create a PR with the changes made by Melos.                                                       |
 | pr-title                  | chore(release): Publish packages                | The title to use for the PR created when `create-pr` is true.                                                |

--- a/action.yml
+++ b/action.yml
@@ -178,16 +178,28 @@ runs:
       if: ${{ inputs.create-release == 'true' }}
       # Read the section for $PACKAGE_VERSION out of the package's CHANGELOG.md.
       # The section starts at the "## <version>" header and ends at the next
-      # "## " header (or the end of the file).
+      # "## " header (or the end of the file). The version is matched exactly
+      # against the header's version token so "1.2.3" does not match "1.2.30".
       run: |
         PACKAGE_PATH=$(melos list --json | jq -r ".[] | select(.name == \"$PACKAGE_NAME\") | .location")
         CHANGELOG_PATH="$PACKAGE_PATH/CHANGELOG.md"
         if [ -f "$CHANGELOG_PATH" ]; then
-          CHANGELOG_CONTENT=$(awk -v header="## $PACKAGE_VERSION" 'index($0,header)==1{flag=1;next} /^## /{flag=0} flag' "$CHANGELOG_PATH")
+          CHANGELOG_CONTENT=$(awk -v ver="$PACKAGE_VERSION" '/^## /{flag=($2==ver); next} flag' "$CHANGELOG_PATH")
         else
           echo "No CHANGELOG.md found at $CHANGELOG_PATH, creating release without notes."
           CHANGELOG_CONTENT=""
         fi
+        # Detect prerelease from the version, ignoring "+build" metadata (which
+        # may itself contain a "-"). A "-" in the version core marks a prerelease.
+        if [ "${{ inputs.release-prerelease }}" = "auto" ]; then
+          case "${PACKAGE_VERSION%%+*}" in
+            *-*) IS_PRERELEASE=true ;;
+            *) IS_PRERELEASE=false ;;
+          esac
+        else
+          IS_PRERELEASE="${{ inputs.release-prerelease }}"
+        fi
+        echo "RELEASE_PRERELEASE=$IS_PRERELEASE" >> $GITHUB_ENV
         {
           echo "RELEASE_BODY<<MELOS_RELEASE_EOF"
           echo "$CHANGELOG_CONTENT"
@@ -207,4 +219,4 @@ runs:
         tag_name: ${{ env.PACKAGE_NAME }}-v${{ env.PACKAGE_VERSION }}
         name: ${{ env.PACKAGE_NAME }} v${{ env.PACKAGE_VERSION }}
         body: ${{ env.RELEASE_BODY }}
-        prerelease: ${{ inputs.release-prerelease == 'auto' && contains(env.PACKAGE_VERSION, '-') || inputs.release-prerelease == 'true' }}
+        prerelease: ${{ env.RELEASE_PRERELEASE }}

--- a/action.yml
+++ b/action.yml
@@ -61,6 +61,20 @@ inputs:
     description: 'Whether packages should be published to pub.dev (default: false)'
     required: false
     default: 'false'
+  create-release:
+    description: >-
+      Whether a GitHub release should be created for the package related to the
+      tag that triggered the workflow. The release notes are extracted from the
+      package's CHANGELOG.md for the released version (default: false)
+    required: false
+    default: 'false'
+  release-prerelease:
+    description: >-
+      Whether the created GitHub release should be marked as a prerelease. By
+      default this is detected automatically from the version (any version
+      containing a `-`, e.g. `1.2.3-dev.1`, is treated as a prerelease)
+    required: false
+    default: 'auto'
   create-pr:
     description: 'Whether a PR should be created with the versioning changes (default: false)'
     required: false
@@ -139,7 +153,7 @@ runs:
         for tag in $(git tag --points-at HEAD); do git push origin "$tag"; done
       shell: bash
     - name: 'Extract tag info'
-      if: ${{ inputs.publish == 'true' }}
+      if: ${{ inputs.publish == 'true' || inputs.create-release == 'true' }}
       env:
         GITHUBREF: ${{ github.ref }}
       # Support semver, e.g.: "refs/tags/my_package-v1.2.3+alpha.1"
@@ -147,6 +161,9 @@ runs:
         PACKAGE_NAME=$(sed -E 's/refs\/tags\/([a-z0-9_]+)-v([0-9]+\.[0-9]+\.[0-9]+.*)$/\1/' <<< $GITHUBREF) && \
         echo "PACKAGE_NAME=$PACKAGE_NAME" >> $GITHUB_ENV
         echo "Package name: $PACKAGE_NAME"
+        PACKAGE_VERSION=$(sed -E 's/refs\/tags\/([a-z0-9_]+)-v([0-9]+\.[0-9]+\.[0-9]+.*)$/\2/' <<< $GITHUBREF) && \
+        echo "PACKAGE_VERSION=$PACKAGE_VERSION" >> $GITHUB_ENV
+        echo "Package version: $PACKAGE_VERSION"
       shell: bash
     - name: 'Installs the Dart SDK and sets up the pipeline for usage with pub.dev (this sets up OIDC)'
       if: ${{ inputs.publish == 'true' && inputs.dart-version != 'none' }}
@@ -157,3 +174,37 @@ runs:
       if: ${{ inputs.publish == 'true' }}
       run: melos publish -y --no-dry-run --scope=$PACKAGE_NAME
       shell: bash
+    - name: 'Extract changelog for the release'
+      if: ${{ inputs.create-release == 'true' }}
+      # Read the section for $PACKAGE_VERSION out of the package's CHANGELOG.md.
+      # The section starts at the "## <version>" header and ends at the next
+      # "## " header (or the end of the file).
+      run: |
+        PACKAGE_PATH=$(melos list --json | jq -r ".[] | select(.name == \"$PACKAGE_NAME\") | .path")
+        CHANGELOG_PATH="$PACKAGE_PATH/CHANGELOG.md"
+        if [ -f "$CHANGELOG_PATH" ]; then
+          CHANGELOG_CONTENT=$(awk -v header="## $PACKAGE_VERSION" 'index($0,header)==1{flag=1;next} /^## /{flag=0} flag' "$CHANGELOG_PATH")
+        else
+          echo "No CHANGELOG.md found at $CHANGELOG_PATH, creating release without notes."
+          CHANGELOG_CONTENT=""
+        fi
+        {
+          echo "RELEASE_BODY<<MELOS_RELEASE_EOF"
+          echo "$CHANGELOG_CONTENT"
+          if [ "${{ inputs.publish }}" = "true" ]; then
+            echo ""
+            echo "---"
+            echo "Published to pub.dev: https://pub.dev/packages/$PACKAGE_NAME/versions/$PACKAGE_VERSION"
+          fi
+          echo "MELOS_RELEASE_EOF"
+        } >> $GITHUB_ENV
+      shell: bash
+    - name: 'Create GitHub release'
+      if: ${{ inputs.create-release == 'true' }}
+      uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
+      with:
+        token: ${{ inputs.token }}
+        tag_name: ${{ env.PACKAGE_NAME }}-v${{ env.PACKAGE_VERSION }}
+        name: ${{ env.PACKAGE_NAME }} v${{ env.PACKAGE_VERSION }}
+        body: ${{ env.RELEASE_BODY }}
+        prerelease: ${{ inputs.release-prerelease == 'auto' && contains(env.PACKAGE_VERSION, '-') || inputs.release-prerelease == 'true' }}

--- a/action.yml
+++ b/action.yml
@@ -180,7 +180,7 @@ runs:
       # The section starts at the "## <version>" header and ends at the next
       # "## " header (or the end of the file).
       run: |
-        PACKAGE_PATH=$(melos list --json | jq -r ".[] | select(.name == \"$PACKAGE_NAME\") | .path")
+        PACKAGE_PATH=$(melos list --json | jq -r ".[] | select(.name == \"$PACKAGE_NAME\") | .location")
         CHANGELOG_PATH="$PACKAGE_PATH/CHANGELOG.md"
         if [ -f "$CHANGELOG_PATH" ]; then
           CHANGELOG_CONTENT=$(awk -v header="## $PACKAGE_VERSION" 'index($0,header)==1{flag=1;next} /^## /{flag=0} flag' "$CHANGELOG_PATH")
@@ -201,7 +201,7 @@ runs:
       shell: bash
     - name: 'Create GitHub release'
       if: ${{ inputs.create-release == 'true' }}
-      uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
+      uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
       with:
         token: ${{ inputs.token }}
         tag_name: ${{ env.PACKAGE_NAME }}-v${{ env.PACKAGE_VERSION }}

--- a/examples/01-workflow-dispatch/release-publish.yml
+++ b/examples/01-workflow-dispatch/release-publish.yml
@@ -21,3 +21,5 @@ jobs:
       - uses: bluefireteam/melos-action@v3
         with:
           publish: true
+          # Create a GitHub release with notes from the package's CHANGELOG.md
+          create-release: true

--- a/examples/02-release-on-pr/release-publish.yml
+++ b/examples/02-release-on-pr/release-publish.yml
@@ -21,3 +21,5 @@ jobs:
       - uses: bluefireteam/melos-action@v3
         with:
           publish: true
+          # Create a GitHub release with notes from the package's CHANGELOG.md
+          create-release: true


### PR DESCRIPTION
## Summary

Adds an automatic GitHub release feature to the action, inspired by [supabase-flutter's release workflow](https://github.com/supabase/supabase-flutter/blob/main/.github/workflows/release-publish.yml).

## Changes

**`action.yml`** — two new inputs and the supporting steps:
- **`create-release`** (default `false`): creates a GitHub release for the package tied to the triggering tag.
- **`release-prerelease`** (default `auto`): controls the prerelease flag; `auto` infers it from a `-` in the version (e.g. `1.2.3-dev.1`).
- The existing *Extract tag info* step now also extracts `PACKAGE_VERSION`, and runs when `create-release` is enabled.
- A new *Extract changelog* step finds the package path via `melos list --json | jq`, slices the matching `## <version>` section out of that package's `CHANGELOG.md` (with a graceful fallback if none exists), and — only when `publish: true` — appends a pub.dev link.
- A new *Create GitHub release* step uses `softprops/action-gh-release` (pinned) with the tag, name, changelog body, and computed prerelease flag.

**`README.md`** — documented both new parameters.

**Examples** — added `create-release: true` to the `release-publish.yml` in `01-workflow-dispatch` and `02-release-on-pr`.

## Notes
- The release is keyed off the tag ref (`<pkg>-v<version>`), matching the existing publish flow, so it slots in right after publishing.
- Reuses the existing `token` input, so PAT/GitHub App token support carries over. The `contents: write` permission already present in the example publish workflows is what's needed.
- `create-release` works independently of `publish` (the pub.dev link is only added when actually publishing).
- Relies on `melos list --json` exposing a `path` field and `jq` being on the runner (true for GitHub-hosted runners).